### PR TITLE
security: remove hardcoded OAuth credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
-# Google OAuth Credentials
-# Get these from Google Cloud Console > APIs & Services > Credentials
-GOOGLE_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_ID_IOS=your-ios-client-id.apps.googleusercontent.com
-GOOGLE_CLIENT_ID_ANDROID=your-android-client-id.apps.googleusercontent.com
+# Google OAuth Credentials (REQUIRED)
+# Get these from Google Cloud Console: https://console.cloud.google.com/apis/credentials
+# Create OAuth 2.0 Client ID for "Web application"
+EXPO_PUBLIC_GOOGLE_CLIENT_ID=your-client-id-here.apps.googleusercontent.com
 
-# Expo Configuration
-EXPO_USERNAME=your-expo-username
+# Platform-specific OAuth credentials (required for native builds)
+# Create separate OAuth clients for iOS and Android in Google Cloud Console
+EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS=your-ios-client-id.apps.googleusercontent.com
+EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID=your-android-client-id.apps.googleusercontent.com
+
+# Your Expo username (for OAuth redirect URI)
+EXPO_PUBLIC_USERNAME=your-expo-username

--- a/app.config.js
+++ b/app.config.js
@@ -1,5 +1,14 @@
 // Dynamic Expo configuration
 // Environment variables are loaded at build time
+
+// Validate required environment variables
+if (!process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID) {
+  console.warn(
+    'WARNING: EXPO_PUBLIC_GOOGLE_CLIENT_ID is not set. ' +
+      'Google OAuth will not work. See .env.example for setup instructions.'
+  );
+}
+
 export default {
   expo: {
     name: 'Cairn',
@@ -34,11 +43,11 @@ export default {
     plugins: ['expo-router'],
     extra: {
       // OAuth credentials - use EXPO_PUBLIC_ prefix for Expo to load them
-      // Fallback to hardcoded values for development
-      googleClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID || '200611301377-gn4n7u9b89v1g1i0aq0e8dbrmler57dt.apps.googleusercontent.com',
-      googleClientIdIos: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS || '',
-      googleClientIdAndroid: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID || '',
-      expoUsername: process.env.EXPO_PUBLIC_USERNAME || 'manuel.canedo',
+      // See .env.example for required environment variables
+      googleClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
+      googleClientIdIos: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS,
+      googleClientIdAndroid: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID,
+      expoUsername: process.env.EXPO_PUBLIC_USERNAME,
       appSlug: 'cairn',
     },
   },


### PR DESCRIPTION
## Summary

Removes hardcoded Google OAuth Client ID from `app.config.js` now that the repository is public.

## Changes

- Removed hardcoded fallback value for `googleClientId`
- Added console warning when `EXPO_PUBLIC_GOOGLE_CLIENT_ID` is not set
- Updated `.env.example` with correct variable names and setup instructions

## Breaking Change

App now **requires** a `.env` file with valid credentials to function. The hardcoded fallback has been removed.

## Verification

- [x] `npm run typecheck` passes
- [x] Credentials no longer in codebase
- [x] Warning displays when env var missing

---

Closes Task #13

🤖 Generated with [Claude Code](https://claude.ai/claude-code)