### PR TITLE
ci: add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI workflow to run on all pushes and PRs.

## What it does

- Type checking (`npm run typecheck`)
- Test suite with coverage (`npm run test:coverage`)
- Linting (`npm run lint`)
- Uploads coverage report as artifact (7 day retention)

## Job name

The job is named `test` to match the branch protection status check requirement.

## Verification

- [x] YAML syntax valid
- [x] Job name matches branch protection requirement

---

Closes Task #4

🤖 Generated with [Claude Code](https://claude.ai/claude-code)